### PR TITLE
Fix doc link for "theming" page

### DIFF
--- a/src/docs/color.mdx
+++ b/src/docs/color.mdx
@@ -12,7 +12,7 @@ import { Grid, BoxColor } from "./utils/BoxColor";
 theme.palette.<COLOR_NAME>.<VARIATION>
 ```
 
-Violin has a pallete color and you can [change this palette](/styles/theme).
+Violin has a pallete color and you can [change this palette](/theming).
 
 ## primary
 


### PR DESCRIPTION
The link "change this palette" in the page https://violin-ui.netlify.com/colors is broken.